### PR TITLE
Factored fc harbor

### DIFF
--- a/tnn/cell.py
+++ b/tnn/cell.py
@@ -233,7 +233,8 @@ def input_aggregator(inputs, shape, spatial_op, channel_op, kernel_init='xavier'
                     print("factored fc name", nm)
                     nm = 'factored_fc_harbor_for_' + nm
                     with tf.variable_scope(nm, reuse=reuse):
-                        out = factored_fc(inp, out_depth=out_depth_per_input, activation=None, flatten=False, bias=0.0)
+                        assert out_depth_per_input is not None
+                        out = factored_fc(inp, out_depth=out_depth_per_input, spatial_mask_init=kernel_init, spatial_mask_init_kwargs=kernel_init_kwargs, feature_kernel_init=kernel_init, feature_kernel_init_kwargs=kernel_init_kwargs, activation=activation, flatten=False, bias=0.0)
                 else:
                     out = tf.image.resize_images(inp, shape[1:3], align_corners=True)
 

--- a/tnn/cell.py
+++ b/tnn/cell.py
@@ -230,7 +230,6 @@ def input_aggregator(inputs, shape, spatial_op, channel_op, kernel_init='xavier'
                     out = deconv(inp, shape=shape, weight_decay=weight_decay, ksize=ksize, activation=activation, padding=padding, reuse=reuse)
                 elif spatial_op == 'factored_fc':
                     nm = pat.sub('__', inp.name.split('/')[-2].split('_')[0])
-                    print("factored fc name", nm)
                     nm = 'factored_fc_harbor_for_' + nm
                     with tf.variable_scope(nm, reuse=reuse):
                         assert out_depth_per_input is not None


### PR DESCRIPTION
"factored_fc" now a valid spatial_op for harbor. This applies to an HxWxD input tensor a combination of one HxW spatial mask and one set of D feature weights per output. N, the number of output channels, is specified by out_depth_per_input kwarg to harbor. For example, if two inputs are combined in the harbor using out_depth_per_input=512 and channel_op="concat", the output of the harbor will be a [B,1,1,1024] tensor. 