### PR TITLE
Cross gpu batch norm

### DIFF
--- a/tnn/cell.py
+++ b/tnn/cell.py
@@ -716,6 +716,7 @@ def component_conv(inp,
          return_input=False,
          time_sep=False,
          time_suffix=None,
+         crossgpu_bn_kwargs={'use_crossgpu_bn': False},
          name='component_conv'
          ):
 
@@ -796,7 +797,8 @@ harbor channel op of concat. Other channel ops should work with tfutils.model.co
                                               epsilon = batch_norm_epsilon, 
                                               init_zero=init_zero, 
                                               activation=activation,
-                                              time_suffix=time_suffix)
+                                              time_suffix=time_suffix,
+                                              **crossgpu_bn_kwargs)
         except:
             output = tfutils.model_tool_old.batchnorm_corr(inputs=output, 
                                               is_training=is_training, 
@@ -805,7 +807,8 @@ harbor channel op of concat. Other channel ops should work with tfutils.model.co
                                               epsilon = batch_norm_epsilon, 
                                               init_zero=init_zero, 
                                               activation=activation,
-                                              time_suffix=time_suffix)
+                                              time_suffix=time_suffix,
+                                              **crossgpu_bn_kwargs)
 
     if activation is not None:
         output = getattr(tf.nn, activation)(output, name=activation)
@@ -832,6 +835,7 @@ def conv_bn(inp,
             batch_norm_decay=0.9,
             batch_norm_epsilon=1e-5,
             init_zero=None,
+            crossgpu_bn_kwargs={'use_crossgpu_bn': False},
             name='conv'):
 
     # assert out_shape is not None
@@ -879,7 +883,8 @@ def conv_bn(inp,
                                               decay = batch_norm_decay, 
                                               epsilon = batch_norm_epsilon, 
                                               init_zero=init_zero, 
-                                              activation=activation)
+                                              activation=activation,
+                                              **crossgpu_bn_kwargs)
         except:
             output = tfutils.model_tool_old.batchnorm_corr(inputs=output, 
                                               is_training=is_training, 
@@ -887,7 +892,8 @@ def conv_bn(inp,
                                               decay = batch_norm_decay, 
                                               epsilon = batch_norm_epsilon, 
                                               init_zero=init_zero, 
-                                              activation=activation)
+                                              activation=activation,
+                                              **crossgpu_bn_kwargs)
     
     if activation is not None:
         output = getattr(tf.nn, activation)(output, name=activation)

--- a/tnn/cell.py
+++ b/tnn/cell.py
@@ -617,7 +617,7 @@ def memory(inp, state, memory_decay=0, trainable=False, name='memory'):
     return state
 
 def residual_add(inp, res_inp, dtype=tf.float32, kernel_init='xavier', kernel_init_kwargs=None, strides=[1,1,1,1], 
-                 padding='SAME', batch_norm=False, is_training=False, init_zero=None, 
+                 padding='SAME', batch_norm=False, is_training=False, init_zero=None, crossgpu_bn_kwargs={'use_crossgpu_bn': False},
                  batch_norm_decay=0.9, batch_norm_epsilon=1e-5, sp_resize=True, time_sep=False, time_suffix=None):
 
     
@@ -650,7 +650,8 @@ def residual_add(inp, res_inp, dtype=tf.float32, kernel_init='xavier', kernel_in
                                                           init_zero=init_zero, 
                                                           activation=None, 
                                                           data_format='channels_last',
-                                                          time_suffix=time_suffix)
+                                                          time_suffix=time_suffix,
+                                                          **crossgpu_bn_kwargs)
             except:
                 projection_out = tfutils.model_tool_old.batchnorm_corr(inputs=projection_out, 
                                                           is_training=is_training, 
@@ -659,7 +660,8 @@ def residual_add(inp, res_inp, dtype=tf.float32, kernel_init='xavier', kernel_in
                                                           init_zero=init_zero, 
                                                           activation=None, 
                                                           data_format='channels_last',
-                                                          time_suffix=time_suffix)
+                                                          time_suffix=time_suffix,
+                                                          **crossgpu_bn_kwargs)
         return tf.add(inp, projection_out)
     else: # shape mismatch in spatial dimension
         if sp_resize: # usually do this if strides are kept to 1 always
@@ -682,7 +684,8 @@ def residual_add(inp, res_inp, dtype=tf.float32, kernel_init='xavier', kernel_in
                                                           init_zero=init_zero, 
                                                           activation=None, 
                                                           data_format='channels_last',
-                                                          time_suffix=time_suffix)
+                                                          time_suffix=time_suffix,
+                                                          **crossgpu_bn_kwargs)
             except:
                 projection_out = tfutils.model_tool_old.batchnorm_corr(inputs=projection_out, 
                                                           is_training=is_training, 
@@ -691,7 +694,9 @@ def residual_add(inp, res_inp, dtype=tf.float32, kernel_init='xavier', kernel_in
                                                           init_zero=init_zero, 
                                                           activation=None, 
                                                           data_format='channels_last',
-                                                          time_suffix=time_suffix)
+                                                          time_suffix=time_suffix,
+                                                          **crossgpu_bn_kwargs)
+
         return tf.add(inp, projection_out)
     
 def component_conv(inp,

--- a/tnn/reciprocalgaternn.py
+++ b/tnn/reciprocalgaternn.py
@@ -247,10 +247,6 @@ class ReciprocalGateCell(ConvRNNCell):
 
         print('Setting edges init zero to be', self._edges_init_zero)
 
-#        self._partitioner = tf.variable_axis_size_partitioner(max_shard_bytes=(64 << 20)-1, axis=0)
-#        self._partitioner = tf.fixed_size_partitioner(num_shards=8, axis=0)
-        self._partitioner = None
-
     def state_size(self):
         return {'cell':self._cell_size, 'out':self._size}
 
@@ -583,7 +579,7 @@ class ReciprocalGateCell(ConvRNNCell):
         else:
             prev_out = state
         
-        with tf.variable_scope(type(self).__name__, partitioner=self._partitioner): # "ReciprocalGateCell"
+        with tf.variable_scope(type(self).__name__): # "ReciprocalGateCell"
 
             with tf.variable_scope('input'):
 


### PR DESCRIPTION
Added support for ops to have cross gpu batch normalization, as in tfutils. Useful for when the batch size per GPU is small.